### PR TITLE
Add culture handbook and reviewer workflow

### DIFF
--- a/.github/workflows/ci-review.yml
+++ b/.github/workflows/ci-review.yml
@@ -1,0 +1,68 @@
+name: CI-Review
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  lint-test-review:
+    runs-on: ubuntu-latest
+
+    steps:
+    # 1. チェックアウト
+    - uses: actions/checkout@v4
+
+    # 2. Python Lint & Formatting
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install deps
+      run: |
+        pip install -r requirements.txt
+        pip install pytest pytest-cov ruff
+
+    - name: Ruff Lint
+      run: ruff check .
+
+    # 3. テスト実行
+    - name: Pytest
+      run: pytest --cov=src --cov-report=xml
+
+    # 4. カバレッジ判定
+    - name: Coverage Gate (>=90%)
+      run: |
+        COVER=$(python - <<'PY'
+        import xml.etree.ElementTree as ET, sys
+        cov = ET.parse('coverage.xml').getroot().attrib['line-rate']
+        print(float(cov)*100)
+        PY
+        )
+        echo "Coverage="$COVER
+        if (( $(echo "$COVER < 90" | bc -l) )); then exit 1; fi
+
+    # 5. Reviewer Agent 呼び出し
+    - name: Reviewer Check
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const { default: axios } = require('axios');
+          const fs = require('fs');
+          const tmpl = fs.readFileSync('templates/reviewer_template.yaml','utf8');
+          const artifact = fs.readFileSync('path/to/artifact','utf8');
+          const payload = {
+            template: tmpl,
+            artifact: artifact
+          };
+          const res = await axios.post(process.env.REVIEWER_ENDPOINT, payload, {
+            headers: { 'Authorization': `Bearer ${process.env.REVIEWER_TOKEN}` }
+          });
+          core.setOutput('review_result', res.data.result);
+          if (res.data.result !== 'PASS') {
+            core.setFailed(`Reviewer returned ${res.data.result}`);
+          }
+    env:
+      REVIEWER_ENDPOINT: ${{ secrets.REVIEWER_ENDPOINT }}
+      REVIEWER_TOKEN: ${{ secrets.REVIEWER_TOKEN }}

--- a/docs/culture.md
+++ b/docs/culture.md
@@ -1,0 +1,30 @@
+# Culture Handbook v0.1
+
+## Vision
+> **「誰でも触れてすぐに“イケてる・使いやすい”と感じる AI プロダクトを届ける」**
+
+## Core Values
+1. **Unity of Cool & Usable**  
+   - 見た目・体験・コードのすべてが "おしゃれ ＆ シンプル"  
+2. **Test‑Driven Reliability**  
+   - 失敗を恐れず、テストで安全網を張った上で挑戦する  
+3. **User‑First Thinking**  
+   - 仕様策定の最初と最後に必ずユーザーストーリーを確認  
+4. **Transparent Communication**  
+   - 事実と感想を分け、課題は早期共有  
+5. **Continuous Learning & Improvement**  
+   - 週次ふりかえり (Retrospective) を欠かさない  
+
+## Engineering Principles
+- **Coding Guideline**：PEP8 + Black + Ruff / Prettier  
+- **Commit Rule**：Conventional Commits (`feat:`, `fix:` …)  
+- **Definition of Done**  
+  1. 単体・統合テスト PASS & カバレッジ ≥ 90%  
+  2. Reviewer 「PASS」判定  
+  3. UX Walk‑through で **3クリック以内に目的達成** を確認  
+
+## Decision‑Making Ladder
+1. 自動テスト結果  
+2. Reviewer レポート  
+3. BOSS 進捗レポート  
+4. President 最終承認

--- a/templates/reviewer_template.yaml
+++ b/templates/reviewer_template.yaml
@@ -1,0 +1,31 @@
+# Reviewer Template v0.1
+meta:
+  role: "Reviewer"
+  purpose: "Culture・Intent・Quality Gatekeeper"
+inputs:
+  - company_culture: "<<docs/culture.md>>"
+  - project_spec: "<<PRD.md>>"
+  - artifact: "<<path/to/artifact>>"
+tasks:
+  - id: C01
+    name: "Culture Fit"
+    check: "Is artifact aligned with Core Values?"
+  - id: I01
+    name: "Intent Alignment"
+    check: "Does it satisfy Vision & DoD?"
+  - id: Q01
+    name: "Quality ‑ Code & Tests"
+    check: "Lint PASS, Coverage >= 90%, No critical CVE"
+  - id: U01
+    name: "Usability"
+    check: "Can a first‑time user achieve goal in ≤3 steps?"
+output_format:
+  result: "PASS | FIX | REJECT"
+  issues:
+    - id: "Q‑01"
+      severity: "major"
+      description: "..."
+      fix_hint: "..."
+  summary: "max 150 words"
+stop_condition: "result != 'PASS'"
+tone: "Concise, respectful, actionable"


### PR DESCRIPTION
## Summary
- add culture handbook doc with vision, values, and engineering principles
- define reviewer template YAML
- add CI-Review workflow for lint, tests and reviewer agent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853af0856b883228abab8365ad98820